### PR TITLE
Added a simple function to add color into an existing string

### DIFF
--- a/lib/ansi-color.js
+++ b/lib/ansi-color.js
@@ -42,9 +42,20 @@ function logMessage(message,color) {
   console.log(setColor(message,color));
 }
 
+function replace(full_text, search_regex, color) {
+  try {
+   var regex = new RegExp('(' + search_regex + ')', 'ig');
+	 var new_text = full_text.replace(regex, setColor('$1', color));
+	 return new_text;
+  } catch (e) {
+	 return full_text;  
+  }
+}
+
 if (typeof exports !== "undefined") {
   exports.log = logMessage;
   exports.set = setColor;
+  exports.replace = replace;
 } else if (typeof define !== "undefined") {
   define([], function() { return { set: setColor, log: logMessage };  });
 }


### PR DESCRIPTION
Added a simple function to add color into an existing string. Useful if the text is generated in another module etc. Has a try/catch block to trap invalid regex. Example:

```
var text = 'success: this is a string. But oh look! There is an Error: what are we going to do?';
text = color.replace(text, 'error:', 'red');
text = color.replace(text, 'success:', 'green');
```
