### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "author": "James Smith <james@loopj.com>",
     "keywords": ["ansi", "color", "console"],
     "directories": {"lib": "./lib"},
-    "repositories": [
+    "repository": [
     {
         "type": "git",
         "url": "git://github.com/loopj/commonjs-ansi-color.git"


### PR DESCRIPTION
To use repository instead of repositories.

Installing with `npm` gives the warning `ansi-color@0.2.1 'repositories' (plural) Not supported.`. According to the [docs](https://npmjs.org/doc/json.html#repository) the syntax is `repository`.
