### PR TITLE
Replace 033 with x1b

### DIFF
--- a/lib/ansi-color.js
+++ b/lib/ansi-color.js
@@ -32,9 +32,9 @@ function setColor(str,color) {
   var color_attrs = color.split("+");
   var ansi_str = "";
   for(var i=0, attr; attr = color_attrs[i]; i++) {
-    ansi_str += "\033[" + ANSI_CODES[attr] + "m";
+    ansi_str += "\x1b[" + ANSI_CODES[attr] + "m";
   }
-  ansi_str += str + "\033[" + ANSI_CODES["off"] + "m";
+  ansi_str += str + "\x1b[" + ANSI_CODES["off"] + "m";
   return ansi_str;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "ansi-color",
-    "version": "0.2.1",
+    "name": "@shannonmoeller/ansi-color",
+    "version": "1.0.0",
     "description": "This module provides basic ANSI color code support, to allow you to format your console output with foreground and background colors as well as providing bold, italic and underline support.",
     "author": "James Smith <james@loopj.com>",
     "directories": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@shannonmoeller/ansi-color",
+    "name": "ansi-color",
     "version": "1.0.0",
     "description": "This module provides basic ANSI color code support, to allow you to format your console output with foreground and background colors as well as providing bold, italic and underline support.",
     "author": "James Smith <james@loopj.com>",


### PR DESCRIPTION
`\033` is invalid when using `'use strict';`. This PR changes `\033` to `\x1b`.